### PR TITLE
Add option to create cross-account P2P endpoints

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -13,5 +13,12 @@ NUM_VALIDATORS=4
 ALLOWED_RPC_APIS='ETH,NET,IBFT,ADMIN,TXPOOL'
 SHARD=3
 
+# Optional comma separated enode addresses of peers in other AWS accounts
+CROSS_ACCOUNT_PEERS=""
+
+# Optional comma separated PrivateLink service names to automatically create
+# Interface VPC endpoints for cross-account P2P traffic
+CROSS_ACCOUNT_P2P_SERVICES=""
+
 # For more detailed configuration options
 # see /lib/constants and /lib/genesis/genesis.json

--- a/app.ts
+++ b/app.ts
@@ -7,6 +7,7 @@ import { ArnPrincipal } from 'aws-cdk-lib/aws-iam';
 
 import { CommonInfrastructure } from "./lib/common-infrastructure-stack";
 import { ValidatorFleetInfrastructure, ValidatorFleetInfrastructureProps } from "./lib/validator-fleet-stack";
+import { CROSS_ACCOUNT_P2P_SERVICE_NAMES } from './lib/constants/network';
 
 const app = new cdk.App();
 cdk.Tags.of(app).add("Project", "PrivateChain");
@@ -22,7 +23,8 @@ if (process.env.USER && process.env.AWS_ACCOUNT_ID) {
         {
             shardId: '1',
             stage: 'dev',
-            env: stackEnv
+            env: stackEnv,
+            crossAccountP2pServices: CROSS_ACCOUNT_P2P_SERVICE_NAMES,
         },
     );
     const devValidatorFleetInfraProps: ValidatorFleetInfrastructureProps = {

--- a/lib/common-infrastructure-stack.ts
+++ b/lib/common-infrastructure-stack.ts
@@ -25,6 +25,7 @@ export interface CommonInfrastructureProps extends StackProps {
   readonly shardId: string;
   readonly stage: string;
   readonly env: Environment;
+  readonly crossAccountP2pServices?: string[];
 }
 
 export class CommonInfrastructure extends Stack {
@@ -36,6 +37,7 @@ export class CommonInfrastructure extends Stack {
   private fleetConfigBucket: Bucket;
   private vpcEndpointSecurityGroup: ISecurityGroup;
   region: string;
+  private crossAccountP2pServices: string[];
 
   private privateChainCommonInfrastructureS3BucketKey: Key;
 
@@ -44,6 +46,7 @@ export class CommonInfrastructure extends Stack {
     this.stage = props.stage;
     this.region = props.env.region ?? 'us-east-1';
     this.shardId = props.shardId;
+    this.crossAccountP2pServices = props.crossAccountP2pServices ?? [];
     this.createVPCAndSG();
     this.createKeys();
     this.createS3Buckets(props.env.account ?? '');
@@ -208,6 +211,19 @@ export class CommonInfrastructure extends Stack {
         },
       });
     }
+
+    let idx = 0;
+    for (const serviceName of this.crossAccountP2pServices) {
+      this.fleetVpc.addInterfaceEndpoint(`CrossAcctP2PEndpoint${idx++}`, {
+        service: { name: serviceName, port: CLIENT_CONFIG.DISCOVERY_PORT },
+        privateDnsEnabled: false,
+        lookupSupportedAzs: false,
+        securityGroups: [this.vpcEndpointSecurityGroup],
+        subnets: {
+          subnetType: SubnetType.PRIVATE_ISOLATED,
+        },
+      });
+    }
   }
 
   private createVPCEndPointSecurityGroup(): ISecurityGroup {
@@ -219,6 +235,17 @@ export class CommonInfrastructure extends Stack {
       this.fleetSecurityGroup,
       Port.tcp(NETWORK_CONFIG.TLS_PORT),
       'All https traffic allowed from vals to vpc endpoints',
+    );
+
+    vpcEndpointSecurityGroup.addIngressRule(
+      this.fleetSecurityGroup,
+      Port.tcp(CLIENT_CONFIG.DISCOVERY_PORT),
+      'P2P tcp traffic from validators',
+    );
+    vpcEndpointSecurityGroup.addIngressRule(
+      this.fleetSecurityGroup,
+      Port.udp(CLIENT_CONFIG.DISCOVERY_PORT),
+      'P2P udp traffic from validators',
     );
 
     return vpcEndpointSecurityGroup;

--- a/lib/constants/network.ts
+++ b/lib/constants/network.ts
@@ -2,3 +2,19 @@ export const NETWORK_CONFIG = {
   TLS_PORT: 443,
   HTTP_PORT: 80,
 };
+
+export interface CrossAccountPeerConfig {
+  /**
+   * enode address of the peer node reachable via PrivateLink
+   */
+  enode: string;
+}
+
+export const CROSS_ACCOUNT_PEERS: CrossAccountPeerConfig[] = process.env.CROSS_ACCOUNT_PEERS
+  ? process.env.CROSS_ACCOUNT_PEERS.split(',').map((enode) => ({ enode }))
+  : [];
+
+export const CROSS_ACCOUNT_P2P_SERVICE_NAMES: string[] =
+  process.env.CROSS_ACCOUNT_P2P_SERVICES
+    ? process.env.CROSS_ACCOUNT_P2P_SERVICES.split(',').filter((s) => s)
+    : [];

--- a/lib/constructs/bootnode-artifact-generator.ts
+++ b/lib/constructs/bootnode-artifact-generator.ts
@@ -16,6 +16,7 @@ export interface BootNodeArtifactGeneratorProps {
   readonly shardId: string;
   readonly configBucket: Bucket;
   readonly validatorKeySet: ValidatorECCKeySet;
+  readonly crossAccountPeers?: string[];
   readonly version?: number;
 }
 
@@ -36,6 +37,7 @@ export class BootNodeArtifactGenerator extends Construct {
         environment: {
           CONFIG_BUCKET: props.configBucket.bucketName,
           SHARD_ID: props.shardId,
+          CROSS_ACCOUNT_PEERS: props.crossAccountPeers?.join(',') ?? '',
         },
         runtime: Runtime.NODEJS_LATEST,
       },

--- a/lib/lambda-functions/bootnode-artifact-generator-func.ts
+++ b/lib/lambda-functions/bootnode-artifact-generator-func.ts
@@ -23,7 +23,11 @@ export const handler: Handler = async (event, context) => {
       CLIENT_CONFIG.DISCOVERY_PORT.toString(),
     ),
   );
-  await uploadStringAsFile(fileName, JSON.stringify(enodes), process.env.CONFIG_BUCKET as string);
+  const crossAccountPeers = process.env.CROSS_ACCOUNT_PEERS
+    ? process.env.CROSS_ACCOUNT_PEERS.split(',').filter((p) => p)
+    : [];
+  const allEnodes = enodes.concat(crossAccountPeers);
+  await uploadStringAsFile(fileName, JSON.stringify(allEnodes), process.env.CONFIG_BUCKET as string);
   console.log('Successfully uploaded statis node file to s3');
 };
 

--- a/test/common-infrastructure-stack.test.ts
+++ b/test/common-infrastructure-stack.test.ts
@@ -14,6 +14,7 @@ describe('Common Infrastructure Stack', () => {
         shardId: '3',
         stage: 'dev',
         env: { account: process.env.AWS_ACCOUNT_ID, region: process.env.AWS_REGION },
+        crossAccountP2pServices: [],
     };
 
     const stack = new CommonInfrastructure(app, 'CommonInfrastructureStack', props);

--- a/test/validator-fleet-infrastructure.test.ts
+++ b/test/validator-fleet-infrastructure.test.ts
@@ -16,6 +16,7 @@ describe('Validator Fleet Infrastructure Stack', () => {
         shardId: process.env.SHARD || '1',
         stage: 'dev',
         env: { account: process.env.AWS_ACCOUNT_ID, region: process.env.AWS_REGION },
+        crossAccountP2pServices: [],
     };
     const commonStack = new CommonInfrastructure(app, 'CommonInfrastructureStack', commonProps);
 


### PR DESCRIPTION
## Summary
- add `CROSS_ACCOUNT_P2P_SERVICES` env variable
- create interface VPC endpoints for cross-account P2P services when configured
- document new flag and clarify setup steps
- update CDK app and tests for the new option

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ac1bb2774832888af02cc9498503d